### PR TITLE
+ make JOIN_TO a list of nodes. may be identical for all nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ So by following a simple **trick** from [https://medium.com/@jmerriweather/elixi
 use Mix.Config
 
 # Takes JOIN_TO env variable provided by deployer (if any) on starting this app 
+# JOIN_TO may be a comma separated list of nodes. The app will connect to the first
+# available foreign node. This way the list of nodes can be identical on all nodes
+# and starting order of apps on different nodes doesn't matter.
 config :distkv, node_addr: System.get_env("JOIN_TO")
 ```
 
@@ -51,6 +54,7 @@ And thanks to [lindenbaum team](https://github.com/lindenbaum) as well, for thei
 
 ## Start 1st node
 ```
+C:\> set JOIN_TO=node_1@YOUR_IP,node_2@YOUR_IP,node_3@YOUR_IP
 C:\> iex --name node_1@YOUR_IP --cookie freak -S mix run
 iex(node_1@YOUR_IP)1> alias Distkv.DkvServer
 iex(node_1@YOUR_IP)2> DkvServer.insert(:one, %{msg: "Hello World"})
@@ -61,7 +65,7 @@ iex(node_1@YOUR_IP)3> DkvServer.select_all
 
 ## Start 2nd node
 ```
-C:\> set JOIN_TO=node_1@YOUR_IP
+C:\> set JOIN_TO=node_1@YOUR_IP,node_2@YOUR_IP,node_3@YOUR_IP
 C:\> iex --name node_2@YOUR_IP --cookie freak -S mix run
 iex(node_2@YOUR_IP)1> alias Distkv.DkvServer
 iex(node_2@YOUR_IP)2> DkvServer.select_all

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,7 +3,7 @@
 use Mix.Config
 
 # Takes JOIN_TO env variable provided by deployer (if any) on starting this app 
-config :distkv, node_addr: System.get_env("JOIN_TO")
+config :distkv, node_addr: System.get_env("JOIN_TO") |> String.split(~r/[, ]+/)
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this


### PR DESCRIPTION
I implemented that JOIN_TO can be an identical list of nodes for all nodes. The app will connect to the first available foreign node. Besides the node name itself the configuration now can be the same for each deployment.